### PR TITLE
fix tiny typo

### DIFF
--- a/src/process.js
+++ b/src/process.js
@@ -572,7 +572,7 @@ function handleReloading() {
 function startWorker(cb) {
 	// register shutdown task
 	module.exports.addShutdownTask(ee.unregisterRole);
-	// set up message lsitener: master to worker
+	// set up message listener: master to worker
 	process.on('message', function (data) {
 		switch (data.command) {
 			case CMD.EXIT:


### PR DESCRIPTION
I was reading the code to get a better sense of how to use the cluster api, and I found this little typo